### PR TITLE
Add trove classifiers for python versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,5 +25,10 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         'Framework :: Django',
     ])


### PR DESCRIPTION
I'm converting a project to Python 3. These classifiers help tools like caniusepython3 know which dependencies support which versions, so they might save someone a click :)