### PR TITLE
fixed error on input address placeholder

### DIFF
--- a/geoposition/static/geoposition/google.js
+++ b/geoposition/static/geoposition/google.js
@@ -38,7 +38,7 @@ if (jQuery != undefined) {
                 $mapContainer = $('<div class="geoposition-map" />'),
                 $addressRow = $('<div class="geoposition-address" />'),
                 $searchRow = $('<div class="geoposition-search" />'),
-                $searchInput = $('<input>', {'type': 'text', 'placeholder': django.gettext('Input an address...')}),
+                $searchInput = $('<input>', {'type': 'text', 'placeholder': 'Input an address...'}),
                 $latitudeField = $container.find('input.geoposition:eq(0)'),
                 $longitudeField = $container.find('input.geoposition:eq(1)'),
                 latitude = parseFloat($latitudeField.val()) || null,


### PR DESCRIPTION
fixed error on input address placeholder
Apparently the problem was that a reference to djangojs use has been left in the google.js code and it did not allow to render the widget
