### PR TITLE
refresh tox requirements and fix ci

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,22 +12,17 @@ jobs:
         python-version: ['3.6', '3.8']
 
     steps:
-    - name: Add deadnakes ppa
-      run: |
-        sudo apt install -qqyf software-properties-common
-        sudo add-apt-repository ppa:deadsnakes/ppa -y
-    - name: Install dependencies
-      run: |
-        sudo apt update -qq
-        sudo apt install --no-install-recommends -qqyf python3.6
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+
     - name: install tox
       run: |
         python -m pip install --upgrade pip
-        python -m pip install tox
+        python -m pip install tox tox-py==1.1.0
+
     - name: run tox
-      run: tox
+      run: tox --py current

--- a/tox.ini
+++ b/tox.ini
@@ -5,12 +5,12 @@
 [tox]
 envlist =
         py36-django{2.2,3.2}
-        py38-django{2.2,3.2,4.0}
+        py38-django{3.2,4.0}
 
 [testenv]
 commands = {envpython} manage.py test geoposition
 
 deps =
-    django2.2: Django==2.2.27
-    django3.2: Django==3.2.12
-    django4.0: Django==4.0.3
+    django2.2: Django==2.2.*
+    django3.2: Django==3.2.*
+    django4.0: Django==4.0.*


### PR DESCRIPTION
Fix and cleanup ci setup.

Stop testing Django 2.2 on python 3.8 since extended support ended this
april. Then remove hardcoded patch version using the * instead to
avoid staying in sync with releases.